### PR TITLE
(MODULES-3132) Handle UTF-8 files with BOMs

### DIFF
--- a/lib/mof/helper.rb
+++ b/lib/mof/helper.rb
@@ -9,19 +9,19 @@ module MOF
 module Helper
 
   require 'pathname'
-  
+
   def lineno
     @lineno
   end
-  
+
   def name
     @name
   end
-  
+
   def style
     @style
   end
-  
+
   #
   # open file for parsing
   #
@@ -67,7 +67,7 @@ module Helper
 	raise "Cannot open #{name}"
       end
     end
-    @fstack << [ @file, @name, @lineno, @iconv, $/, @result ] if @file  
+    @fstack << [ @file, @name, @lineno, @iconv, $/, @result ] if @file
     @file = file
     @name = name
     @lineno = 1
@@ -116,11 +116,11 @@ module Helper
 
     valid
   end
-  
+
   #----------------------------------------------------------
   # Error classes
   #
-  
+
   # to be used to flag @style issues
   class Error < ::SyntaxError
     attr_reader :name, :lineno, :line, :msg
@@ -131,13 +131,13 @@ module Helper
       "#{@name}:#{@lineno}: #{line}\n#{msg}"
     end
   end
-  
+
   class ScannerError < Error
     def initialize name, lineno, line, msg
       super name,lineno,line,"Unrecognized '#{msg}'"
     end
   end
-  
+
   class ParserError < Error
     attr_reader :line, :token, :token_value, :stack
     def initialize name, lineno, line, token, token_value, stack
@@ -169,10 +169,10 @@ module Helper
       ret
     end
   end
-  
+
   class StyleError < Error
   end
-  
+
   public
   #
   # error_handler
@@ -193,6 +193,6 @@ module Helper
       $stderr.puts $@
     end
   end
-  
+
 end # module Helper
 end # module MOF

--- a/lib/mof/helper.rb
+++ b/lib/mof/helper.rb
@@ -74,10 +74,10 @@ module Helper
     @result = MOF::Result.new
     # read the byte order mark to check for utf-16 windows files
     bom = @file.read(2)
-    if bom == "\376\377"
+    if bom.bytes == [0xFE, 0xFF]
       @iconv = "UTF-16BE"
       $/ = "\0\r\0\n"
-    elsif bom == "\377\376"
+    elsif bom.bytes == [0xFF, 0xFE]
       @iconv = "UTF-16LE"
       $/ = "\r\0\n\0"
     else

--- a/lib/mof/helper.rb
+++ b/lib/mof/helper.rb
@@ -80,15 +80,21 @@ module Helper
     elsif bom == "\377\376"
       @iconv = "UTF-16LE"
       $/ = "\r\0\n\0"
-    elsif ! has_valid_utf8(@name)
-      $stderr.puts "#{name} contains invalid UTF-8, treating as ISO-8859-1"
-      @iconv = "ISO-8859-1"
-      @file.rewind
-      $/ = "\n"
     else
-      @file.rewind
-      @iconv = nil
-      $/ = "\n"
+      bom += @file.read(1)
+      if bom.bytes == [0xEF, 0xBB, 0xBF]
+        @iconv = "UTF-8"
+        $/ = "\r\0\n\0"
+      elsif ! has_valid_utf8(@name)
+        $stderr.puts "#{name} contains invalid UTF-8, treating as ISO-8859-1"
+        @iconv = "ISO-8859-1"
+        @file.rewind
+        $/ = "\n"
+      else
+        @file.rewind
+        @iconv = nil
+        $/ = "\n"
+      end
     end
     @style = :wmi if @iconv
     #  $stderr.puts "$/(#{$/.split('').inspect})"


### PR DESCRIPTION
- Previously, we peeked at the first 2 bytes of a file to find a
  UTF-16LE / UTF-16BE BOM.  However, we never peeked at the third byte
  to see if there is a UTF-8 BOM.
  
  Modify the code to perform that check before degrading to assumptions
  about other encodings.
