### PR TITLE
(WIP)(maint) Fix absolute paths on windows

### DIFF
--- a/lib/mof/helper.rb
+++ b/lib/mof/helper.rb
@@ -36,7 +36,7 @@ module Helper
     else
       $stderr.puts "open #{name} [#{origin}]" unless @quiet
       file = nil
-      if name[0,1] == "/"
+      if (Pathname.new name).absolute?
 	# absolute path
 	file = File.open( name ) if File.readable?( name )
       else


### PR DESCRIPTION
This commit updats the helper method to reconize absolute paths on
windows. Previously it assumed all paths began with "/".